### PR TITLE
Updated blueprint reload to include custom blueprints.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ module.exports = function(sails) {
         dirs: [
           path.resolve(sails.config.appPath,'api','controllers'),
           path.resolve(sails.config.appPath,'api','models'),
-          path.resolve(sails.config.appPath,'api','services')
+          path.resolve(sails.config.appPath,'api','services'),
+          path.resolve(sails.config.appPath,'api','blueprints')
         ]
       }
     },
@@ -62,18 +63,17 @@ module.exports = function(sails) {
         // Reload controller middleware
         sails.hooks.controllers.loadAndRegisterControllers(function() {
 
+          // Reload services
+          sails.hooks.services.loadModules(_.noop);
+
+          // Kick off reload of blueprints
+          sails.hooks.blueprints.initialize(_.noop);
+
           // Wait for the ORM to reload
           sails.once('hook:orm:reloaded', function() {
-  
-            // Reload services
-            sails.hooks.services.loadModules(function() {});
 
             // Flush router
             sails.router.flush();
-
-            // Reload blueprints
-            sails.hooks.blueprints.bindShadowRoutes();
-
           });
 
           // Reload ORM

--- a/index.js
+++ b/index.js
@@ -74,6 +74,9 @@ module.exports = function(sails) {
 
             // Flush router
             sails.router.flush();
+            
+            // Reload blueprints
+            sails.hooks.blueprints.bindShadowRoutes();
           });
 
           // Reload ORM


### PR DESCRIPTION
Switched to using initialize the reload blueprints, which includes custom blueprints and overrides. Initialize hooks onto orm reload, so we can safely put it outside of that block and it will run in the correct order.
