### PR TITLE
Don't drop database on reload

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,9 @@ module.exports = function(sails) {
 
         sails.log.verbose("Detected API change -- reloading controllers / models...");
 
+        // don't drop database
+        sails.config.models.migrate = 'safe';
+
         // Reload controller middleware
         sails.hooks.controllers.loadAndRegisterControllers(function() {
 


### PR DESCRIPTION
Suppress `sails.config.models.migrate` value
