### PR TITLE
Don't drop DB - alter existing models on reload

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,9 @@ module.exports = function(sails) {
       watcher.on('all', sails.util.debounce(function(action, path, stats) {
 
         sails.log.verbose("Detected API change -- reloading controllers / models...");
+ 
+        // don't drop database
+        sails.config.models.migrate = 'alter';
 
         // Reload controller middleware
         sails.hooks.controllers.loadAndRegisterControllers(function() {


### PR DESCRIPTION
This fixes the problem when `sails.config.models.migrate` is set to `drop`. In that case database would be automatically dropped on model reload.
