### PR TITLE
added reloading of controller middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,10 @@ module.exports = function(sails) {
             // Reload services
             sails.hooks.services.loadModules(function() {});
 
-            // Flush router
+            // Reload blueprints on controllers
+            sails.hooks.blueprints.extendControllerMiddleware();
+
+	    // Flush router
             sails.router.flush();
 
             // Reload blueprints


### PR DESCRIPTION
This is needed to bind default blueprint routes in the router.
Without reloading extendControllerMiddleware the following error occours:
Route: 'GET /user/:id' :             'UserController.findOne'

error: Ignored attempt to bind route (/user/:id) to unknown controller.action :: user.findone

This error is not supposed to happen and does only occur on auto realoding, because the controller middleware isn't extended by the blueprint middleware.
