### PR TITLE
Allow migrate policy to be defined in the autoreload configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ active        | ((boolean)) | Whether or not the hook should watch for controlle
 usePolling    | ((boolean)) | Whether or not to use the polling feature. Slower but necessary for certain environments. Defaults to `false`.
 dirs          | ((array)) | Array of strings indicating which folders should be watched.  Defaults to the `api/models`, `api/controllers`, and `api/services` folders. Note that this won't change the set of files being reloaded, but the set of files being watched for changes. As for now, it's not possible to add new directories to be reloaded.
 ignored       | ((array\|string\|regexp\|function)) |  Files and/or directories to be ignored. Pass a string to be directly matched, string with glob patterns, regular expression test, function that takes the testString as an argument and returns a truthy value if it should be matched, or an array of any number and mix of these types. For more examples look up [anymatch docs](https://github.com/es128/anymatch).
+migrate       | ((string))  | The migrate policy (`'drop'`, `'alter'`, `'safe'`) to use for Waterline models when reloading. If present, then the value of models.migrate will be replaced with the value specified here. If omitted, then value of models.migrate will remain unchanged. 
 
 #### Example
 
@@ -39,7 +40,8 @@ module.exports.autoreload = {
   ignored: [
     // Ignore all files with .ts extension
     "**.ts"
-  ]
+  ],
+  migrate: 'safe'
 };
 
 ```

--- a/index.js
+++ b/index.js
@@ -39,6 +39,9 @@ module.exports = function(sails) {
      */
     initialize: function(cb) {
 
+      // Hold the migrate policy for use in the watcher callback.
+      var migratePolicy = sails.config[this.configKey].migrate;
+
       // If the hook has been deactivated, or controllers is deactivated just return
       if (!sails.config[this.configKey].active || !sails.hooks.controllers) {
         sails.log.verbose("Autoreload hook deactivated.");
@@ -66,8 +69,9 @@ module.exports = function(sails) {
 
         sails.log.verbose("Detected API change -- reloading controllers / models...");
 
-        // don't drop database
-        sails.config.models.migrate = 'alter';
+        // Override the global migrate policy if defined in the autoreload configuration.
+        if(migratePolicy)
+          sails.config.models.migrate = migratePolicy;
 
         // Reload controller middleware
         sails.hooks.controllers.loadAndRegisterControllers(function() {


### PR DESCRIPTION
The code currently forces models.migrate = 'alter', which may not be the policy wanted on a project, or at a particular time. The change suggested here would allow the migrate policy to be defined in the autoreload configuration.
