### PR TITLE
Check that a hook is set up before reloading it

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,20 +107,26 @@ module.exports = function(sails) {
 
             // Reload locales
             if (sails.hooks.i18n) {
-                sails.hooks.i18n.initialize(function() {});
+              sails.hooks.i18n.initialize(function() {});
             }
 
             // Reload services
-            sails.hooks.services.loadModules(function() {});
+            if (sails.hooks.services) {
+              sails.hooks.services.loadModules(function() {});
+            }
 
             // Reload blueprints on controllers
-            sails.hooks.blueprints.extendControllerMiddleware();
+            if (sails.hooks.blueprints) {
+              sails.hooks.blueprints.extendControllerMiddleware();
+            }
 
             // Flush router
             sails.router.flush();
 
             // Reload blueprints
-            sails.hooks.blueprints.bindShadowRoutes();
+            if (sails.hooks.blueprints) {
+              sails.hooks.blueprints.bindShadowRoutes();
+            }
 
           });
 


### PR DESCRIPTION
If you, like we've done, disable blueprints for example, then the autoreoad will crash every time you save a file. This adds some really quick and dirty checks before trying to reload hooks.
